### PR TITLE
lib/client: caching descriptor requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -28,23 +28,15 @@ define(['./xhr', './resource'], function(xhr, Resource) {
   Client.prototype.walk = function() {
     var args = Array.prototype.slice.call(arguments);
 
-    if (!this._head) {
-      return this._getRootDescriptor()
-      .then(function(rootResource) {
-        this._head = rootResource;
-
-        if (!args.length) {
-          return this._head;
-        }
-
-        return this._doWalk(args);
-      }.bind(this));
-    }
-
-    return this._doWalk(args);
+    return this._getRootDescriptor()
+    .then(this._doWalk.bind(this, args));
   };
 
-  Client.prototype._doWalk = function(shortNames) {
+  Client.prototype.clearDescriptorCache = function() {
+    delete this._descriptorCache;
+  };
+
+  Client.prototype._doWalk = function(shortNames, head) {
     var self = this;
     var walkerPath = toWalkerPath(shortNames);
     var traversal = this._traversals[walkerPath];
@@ -57,7 +49,7 @@ define(['./xhr', './resource'], function(xhr, Resource) {
       return chain.then(function(resource) {
         return self._getDescriptor(resource.getConnection(shortName));
       });
-    }, Promise.resolve(this._head))
+    }, Promise.resolve(head))
     .then(function(resource) {
       var uri = resource.getConnection('self');
       self._traversals[walkerPath] = uri;
@@ -75,16 +67,25 @@ define(['./xhr', './resource'], function(xhr, Resource) {
   };
 
   Client.prototype._getDescriptor = function(uri) {
+    if ((this._descriptorCache = this._descriptorCache || {})[uri]) {
+      return this._descriptorCache[uri];
+    }
+
     var options = {
       url: uri,
       method: 'options',
       type: 'json'
     };
 
-    return xhr(options)
+    this._descriptorCache[uri] = xhr(options)
     .then(function(descriptor) {
       return new Resource(descriptor);
     });
+
+    this._descriptorCache[uri].catch(function() {
+      delete this._descriptorCache[uri];
+    });
+    return this._descriptorCache[uri];
   };
 
   return Client;

--- a/test/specs/client.js
+++ b/test/specs/client.js
@@ -32,6 +32,10 @@ define(['chai-as-promised', 'lib/client', 'lib/resource'], function(chaiAsPromis
       describe('when given an api root', function() {
         var client = new Client('/v1/foo');
 
+        afterEach(function() {
+          client.clearDescriptorCache();
+        });
+
         describe('that does not conform to the hypermedia format', function() {
           var response = [200, { "Content-Type": "application/json" }, JSON.stringify({})];
 


### PR DESCRIPTION
Descriptor requests are cached by uri. We cache the requests instead of
the request results to avoid multiple calls to walk causing multiple
simultaneous descriptor requests.
